### PR TITLE
MT-122067: Disabled all Si5351 clocks before init and during config

### DIFF
--- a/board/freescale/mt_connect/si5351/si5351.c
+++ b/board/freescale/mt_connect/si5351/si5351.c
@@ -207,7 +207,7 @@ bool SI5351_Init(void)
     }
 
     // configure Output Enable and OEB pin enable control (OEB enabled but OEB pin pulled low)
-    SI5351_WriteRegister(dev, SI5351_OUTPUT_ENABLE, 0x00);
+    SI5351_WriteRegister(dev, SI5351_OUTPUT_ENABLE, 0xFF);
     SI5351_WriteRegister(dev, SI5351_OEB_PIN_ENABLE, 0x00);
 
     // configure PLL input source (CLKIN_DIV = 00b, PLLA_SRC = XTAL, PLLB_SRC = XTAL)


### PR DESCRIPTION
[MT-122067]


[MT-122067]: https://multitracks.atlassian.net/browse/MT-122067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ