### PR TITLE
MT-137351: Set GPIO4_2 and GPIO4_14 as inputs

### DIFF
--- a/board/freescale/mt_connect/mt_connect.c
+++ b/board/freescale/mt_connect/mt_connect.c
@@ -202,7 +202,7 @@ int board_late_init(void)
 	mdelay(1);
 	gpio_set_value(IMX_GPIO_NR(5, 4), 1);
 
-	// BMS (Bootloader Mode Selection)
+	// UBC (U-Boot Console) Mode pins
 	imx_iomux_v3_setup_multiple_pads(sai1_pads, ARRAY_SIZE(sai1_pads));
 	gpio_request(IMX_GPIO_NR(4, 2), "BMS 4-2");
 	gpio_direction_input(IMX_GPIO_NR(4, 2));

--- a/board/freescale/mt_connect/mt_connect.c
+++ b/board/freescale/mt_connect/mt_connect.c
@@ -28,16 +28,22 @@ DECLARE_GLOBAL_DATA_PTR;
 #define I2C_BUS     0           // I2C bus number
 #define SLAVE_ADDR  0x50        // I2C slave address
 
-#define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1)
 #define WDOG_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_ODE | PAD_CTL_PUE | PAD_CTL_PE)
+#define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1)
+#define SAI1_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1)
+
+static iomux_v3_cfg_t const wdog_pads[] = {
+	IMX8MM_PAD_GPIO1_IO02_WDOG1_WDOG_B  | MUX_PAD_CTRL(WDOG_PAD_CTRL),
+};
 
 static iomux_v3_cfg_t const uart_pads[] = {
 	IMX8MM_PAD_UART2_RXD_UART2_RX | MUX_PAD_CTRL(UART_PAD_CTRL),
 	IMX8MM_PAD_UART2_TXD_UART2_TX | MUX_PAD_CTRL(UART_PAD_CTRL),
 };
 
-static iomux_v3_cfg_t const wdog_pads[] = {
-	IMX8MM_PAD_GPIO1_IO02_WDOG1_WDOG_B  | MUX_PAD_CTRL(WDOG_PAD_CTRL),
+static iomux_v3_cfg_t const sai1_pads[] = {
+	IMX8MM_PAD_SAI1_RXD0_GPIO4_IO2 | MUX_PAD_CTRL(SAI1_PAD_CTRL),
+	IMX8MM_PAD_SAI1_TXD2_GPIO4_IO14 | MUX_PAD_CTRL(SAI1_PAD_CTRL),
 };
 
 static iomux_v3_cfg_t const fec_pads[] = {
@@ -97,14 +103,13 @@ struct efi_capsule_update_info update_info = {
 
 int board_early_init_f(void)
 {
+	// WDOG
 	struct wdog_regs *wdog = (struct wdog_regs *)WDOG1_BASE_ADDR;
-
 	imx_iomux_v3_setup_multiple_pads(wdog_pads, ARRAY_SIZE(wdog_pads));
-
 	set_wdog_reset(wdog);
 
+	// UART
 	imx_iomux_v3_setup_multiple_pads(uart_pads, ARRAY_SIZE(uart_pads));
-
 	init_uart_clk(1);
 
 #ifdef CONFIG_NAND_MXS
@@ -191,10 +196,18 @@ int board_late_init(void)
 		printf("SI5351 init failed\n");
 	}
 
+	// ENET
 	gpio_request(IMX_GPIO_NR(5, 4), "ENET PHY Reset");
 	gpio_direction_output(IMX_GPIO_NR(5, 4) , 0);
 	mdelay(1);
 	gpio_set_value(IMX_GPIO_NR(5, 4), 1);
+
+	// BMS (Bootloader Mode Selection)
+	imx_iomux_v3_setup_multiple_pads(sai1_pads, ARRAY_SIZE(sai1_pads));
+	gpio_request(IMX_GPIO_NR(4, 2), "BMS 4-2");
+	gpio_direction_input(IMX_GPIO_NR(4, 2));
+	gpio_request(IMX_GPIO_NR(4, 14), "BMS 4-14");
+	gpio_direction_input(IMX_GPIO_NR(4, 14));
 
 	return 0;
 }


### PR DESCRIPTION
[MT-137351]

To test, set STM PE3 low before powering IMX.
After applying power to the IMX 
 - set PE3 low to boot linux or
 - set PE3 high to remain in uboot

DEVQA: @rvanrooyen 

[MT-137351]: https://multitracks.atlassian.net/browse/MT-137351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ