### PR TITLE
MT-138797: Added support for UART3

### DIFF
--- a/arch/arm/dts/mt-connect.dts
+++ b/arch/arm/dts/mt-connect.dts
@@ -500,6 +500,12 @@
 	status = "okay";
 };
 
+&uart3 { /* debug */
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart3>;
+	status = "okay";
+};
+
 &usbotg1 {
 	hnp-disable;
 	srp-disable;
@@ -695,6 +701,13 @@
 		fsl,pins = <
 		MX8MM_IOMUXC_UART2_RXD_UART2_DCE_RX			0x140
 		MX8MM_IOMUXC_UART2_TXD_UART2_DCE_TX			0x140
+		>;
+	};
+
+	pinctrl_uart3: uart3grp {
+		fsl,pins = <
+		MX8MM_IOMUXC_ECSPI1_SCLK_UART3_DCE_RX 		0x140
+		MX8MM_IOMUXC_ECSPI1_MOSI_UART3_DCE_TX		0x140
 		>;
 	};
 


### PR DESCRIPTION
[MT-138797]

Changes made to keep in lock step with Linux DTS. I have tested UBOOT and M4 .

DEVQA: @rvanrooyen 

FYI @jfraser274 

[MT-138797]: https://multitracks.atlassian.net/browse/MT-138797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ