### PR TITLE
MT-145143: Added uboot version to environment

### DIFF
--- a/board/freescale/mt_connect/mt_connect.c
+++ b/board/freescale/mt_connect/mt_connect.c
@@ -188,6 +188,8 @@ int board_late_init(void)
 		env_set("board_rev", "iMX8MM");
 	}
 	
+	env_set("uboot", CONFIG_MT_UBOOT_VERSION);
+
 	if (true == SI5351_Init())
 	{
 		printf("SI5351 init success\n");

--- a/include/configs/mt_connect.h
+++ b/include/configs/mt_connect.h
@@ -11,6 +11,8 @@
 #include <asm/arch/imx-regs.h>
 #include "imx_env.h"
 
+#define CONFIG_MT_UBOOT_VERSION "0.1.0"
+
 #define UBOOT_ITB_OFFSET			0x57C00
 #define FSPI_CONF_BLOCK_SIZE		0x1000
 #define UBOOT_ITB_OFFSET_FSPI  \


### PR DESCRIPTION
[MT-145143]

DEVQA: @AmeNote-Michael 

Verify PR by flashing uboot, using "mode ubc" and using "printenv" then verify variable uboot is there and set to X.X.X

Update firmware/yocto-bsp/layers/meta-mt-connect/recipes-bsp/u-boot/u-boot-imx_2024.04.bbappend UBOOT_SRC

i.e. UBOOT_SRC = "git://git@github.com/vlaarco/uboot-imx.git;protocol=ssh;branch=MT-145143"

Before building with "bitbake muiltitracks-image-dev" run this: "bitbake -c cleansstate imx-boot"

I always change DISTRO_VERSION in firmware/yocto-bsp/layers/meta-mt-connect/conf/distro/multitracks.conf

This seems to help detect changes.

[MT-145143]: https://multitracks.atlassian.net/browse/MT-145143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ